### PR TITLE
29 Make the summary page printable

### DIFF
--- a/app/static/css/ratemypdf.css
+++ b/app/static/css/ratemypdf.css
@@ -8,6 +8,9 @@ h1 {
 
 body {
   padding: 0 1em 1em 1em;
+  /* Allow stats color bars to be printable */
+  -webkit-print-color-adjust:exact !important;
+  print-color-adjust:exact !important;
 }
 
 
@@ -115,6 +118,31 @@ body {
   /* Adjust location of the checkmark image for smaller devices */
   .checkmark-image {
     margin-top: -250px;
+  }
+}
+
+/* Media query for printable pages */
+@media print {
+  /* Override the accordion button's collapsed style w/ non-collapsed style */
+  .accordion-button {
+    color: #0c63e4;
+    background-color: #e7f1ff;
+    box-shadow: inset 0 -1px 0 rgba(0, 0, 0, .125);
+  }
+  /* Overrides to expand all accordion items */
+  .collapse {
+    display: block!important;
+    height: auto!important;
+  }
+}
+
+/* Workaround to fix a Firefox spacing bug in the first expanded accordion */
+@-moz-document url-prefix() {
+  @media print {
+    .accordion-body {
+      margin-left: 3%;
+      margin-right: 3%;
+    }
   }
 }
 

--- a/app/templates/_stats_partial.html
+++ b/app/templates/_stats_partial.html
@@ -421,39 +421,39 @@
                 What we can't detect yet
               </button>
             </h2>
-          </div>
-          <div id="collapse-not-detected-yet" class="accordion-collapse collapse" aria-labelledby="heading-not-detected-yet" data-bs-target="#collapse-not-detected-yet" aria-expanded="false" aria-controls="collapse-not-detected-yet">
-            <div class="accordion-body">
-              <p>
-                This is an automated tool, and we can't detect everything that makes a form easy to use yet. 
-                Manually review your form for these good practices:
-              </p>
-              <ul>
-                <li>
-                  Give priority to the fields the litigant needs to complete. Place <a href="https://justiceinnovation.law.stanford.edu/evaluating-court-legal-forms/#design">insider information</a> in less prominent places on your form.
-                </li>
-                <li>
-                  Use headings and whitespace to make it easy for the litigant to find important information and to group fields together.
-                </li>
-                <li>
-                  Don't ask questions you do not need the answer to. A <a href="https://www.gov.uk/service-manual/design/form-structure#know-why-youre-asking-every-question">question protocol</a> can help. 
-                  You can also <a href="https://suffolklitlab.org/form-explorer/compare/">see what other states are doing</a> on forms with similar topics.
-                </li>
-                <li>
-                  Especially avoid traumatic questions that are not required or that repeat information you can get from another source.
-                </li>
-                <li>
-                  Consider adding a guided interview for especially complex forms that require litigant choices. Our <a href="https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/">free tools</a>
-                  can help.
-                </li>
-                <li>
-                  If your budget and time allow, consider a <a href="https://www.ncsc.org/__data/assets/pdf_file/0017/42722/User-testing.pdf">usability test</a>.
-                  Usability testing can be done with as few as 5 litigants and can help you identify problems with your form that are not detected by automated tools.
-                </li>
-              </ul>
+            <div id="collapse-not-detected-yet" class="accordion-collapse collapse" aria-labelledby="heading-not-detected-yet" data-bs-parent="#suggestionsAccordion">
+              <div class="accordion-body">
+                <p>
+                  This is an automated tool, and we can't detect everything that makes a form easy to use yet. 
+                  Manually review your form for these good practices:
+                </p>
+                <ul>
+                  <li>
+                    Give priority to the fields the litigant needs to complete. Place <a href="https://justiceinnovation.law.stanford.edu/evaluating-court-legal-forms/#design">insider information</a> in less prominent places on your form.
+                  </li>
+                  <li>
+                    Use headings and whitespace to make it easy for the litigant to find important information and to group fields together.
+                  </li>
+                  <li>
+                    Don't ask questions you do not need the answer to. A <a href="https://www.gov.uk/service-manual/design/form-structure#know-why-youre-asking-every-question">question protocol</a> can help. 
+                    You can also <a href="https://suffolklitlab.org/form-explorer/compare/">see what other states are doing</a> on forms with similar topics.
+                  </li>
+                  <li>
+                    Especially avoid traumatic questions that are not required or that repeat information you can get from another source.
+                  </li>
+                  <li>
+                    Consider adding a guided interview for especially complex forms that require litigant choices. Our <a href="https://suffolklitlab.org/docassemble-AssemblyLine-documentation/docs/">free tools</a>
+                    can help.
+                  </li>
+                  <li>
+                    If your budget and time allow, consider a <a href="https://www.ncsc.org/__data/assets/pdf_file/0017/42722/User-testing.pdf">usability test</a>.
+                    Usability testing can be done with as few as 5 litigants and can help you identify problems with your form that are not detected by automated tools.
+                  </li>
+                </ul>
+              </div>
             </div>
           </div>
-      </div>   
+        </div>   
       </section>
 
       <section class="pdf-statistics-section mt-4">


### PR DESCRIPTION
Expand all accordions for the print version of the stats page.
Standardize accordion items.
Make the stats color bars and headline background printable.

Reference prints saved as PDFs are linked in the ticket: https://github.com/SuffolkLITLab/RateMyPDF/issues/29